### PR TITLE
5: Fix the sorting order of the output

### DIFF
--- a/lib/log_parser_kata/parser.rb
+++ b/lib/log_parser_kata/parser.rb
@@ -10,16 +10,14 @@ module LogParserKata
       @paths_by_total_views ||= log_lines_by_path.
         keys.
         map { |path| [path, log_lines_by_path[path].size] }.
-        sort_by(&:last).
-        reverse
+        sort_by { |(path, views)| [-(views), path] }
     end
 
     def paths_by_unique_views
       @paths_by_unique_views ||= log_lines_by_path.
         keys.
         map { |path| [path, log_lines_by_path[path].uniq.size] }.
-        sort_by(&:last).
-        reverse
+        sort_by { |(path, views)| [-(views), path] }
     end
 
     private

--- a/spec/fixtures/output.txt
+++ b/spec/fixtures/output.txt
@@ -9,10 +9,10 @@ Paths by total views:
 
 Paths by unique views:
 
-/index 23
-/home 23
 /contact 23
 /help_page/1 23
+/home 23
+/index 23
 /about/2 22
 /about 21
 


### PR DESCRIPTION
The first version didn't take multiple entries with the same number of views
into account. This version fixes this and sorts 1. by number of views in
descending order and 2. by path in ascending alphabetical order.